### PR TITLE
allow relative paths to archive. This wasn't possible before 

### DIFF
--- a/lib/TAP/Harness/Archive.pm
+++ b/lib/TAP/Harness/Archive.pm
@@ -321,7 +321,7 @@ sub aggregator_from_archive {
     my ($class, $args) = @_;
     my $meta;
 
-    my $file = $args->{archive}
+    my $file = Cwd::abs_path( $args->{archive} )
       or $class->_croak("You must provide the path to the archive!");
 
     my $is_directory = -d $file;


### PR DESCRIPTION
... as the code chdir() to the temporary directory where the archive is unpacked.
