### PR TITLE
Bump base.pm requirement

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -19,6 +19,7 @@ my $builder = Module::Build->new(
         'File::Path'       => 0,
         'File::Find'       => 0,
         'YAML::Tiny'       => 0,
+        'base'             => 2.18,
     },
     create_readme      => 1,
 );

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -7,6 +7,7 @@ WriteMakefile
           'EXE_FILES' => [],
           'VERSION_FROM' => 'lib/TAP/Harness/Archive.pm',
           'PREREQ_PM' => {
+                           'base' => '2.18',
                            'YAML::Tiny' => 0,
                            'File::Spec' => 0,
                            'TAP::Harness' => '3.05',


### PR DESCRIPTION
base.pm 2.16 (and maybe older) shipped with perl 5.14 has some issues with loading TAP::Harness.

ref: https://github.com/Perl-Toolchain-Gang/Test-Harness/issues/42